### PR TITLE
composer.json stdlib dependency now broken

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "zendframework/zend-stdlib": "self.version"
+        "zendframework/zend-stdlib": "2.*"
     }
 }


### PR DESCRIPTION
The 2.0.0 RC5 packages have have now been removed from zendframework/zend-stdlib (and its own dependencies) so the "self.version" reference is no longer valid.

This causes Composer updates to break.
