### PR TITLE
Keep only one file handle open

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,3 @@ php composer.phar install
 
 At that point, follow the instructions in the documentation folder for actual
 usage of the component. (Documentation is forthcoming.)
-
-# Y this fork?
-We need to store multiple values in one field, like Apache Solr can do it.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ php composer.phar install
 
 At that point, follow the instructions in the documentation folder for actual
 usage of the component. (Documentation is forthcoming.)
+
+# Y this fork?
+We need to store multiple values in one field, like Apache Solr can do it.


### PR DESCRIPTION
This pull request fixes issue #6: Only one file handle should be kept open at a time. Only the `Filesystem` class has been touched.
# Description

The Filesystem object with an open file handle is always stored in the static field `Filesystem::$openFile`. If a new file handle is created, the currently active one will be closed. Before each file operation the handle is opened again and seeked to the previous position.

This also allows operations like this to perform well because file handle is not closed until a new one is created:

``` php
$file = new Filesystem("test.txt");
$file->lock(),
$file->write("a");
$file->write("b");
$file->write("c");
$file->unlock();
$file->close();
```
# Example

``` php
$file1 = new Filesystem("file1.txt");
$file2 = new Filesystem("file2.txt");
$file1->lock(); // File handle for file1.txt is opened
$file1->write("a");
$file2->write("b"); // File handle for file1.txt is closed, file handle for file2.txt is opened
$file1->unlock(); // File handle for file2.txt is closed, file handle for file1.txt is opened
$file1->close(); // File handle for file1.txt is closed
$file2->close();
```
