### PR TITLE
fix: call tokenize with document encoding

### DIFF
--- a/library/ZendSearch/Lucene/Document/HTML.php
+++ b/library/ZendSearch/Lucene/Document/HTML.php
@@ -414,7 +414,7 @@ class HTML extends Document
         $wordsToHighlightList = array();
         $analyzer = Analyzer\Analyzer::getDefault();
         foreach ($words as $wordString) {
-            $wordsToHighlightList[] = $analyzer->tokenize($wordString);
+            $wordsToHighlightList[] = $analyzer->tokenize($wordString, $this->_doc->encoding);
         }
         $wordsToHighlight = call_user_func_array('array_merge', $wordsToHighlightList);
 


### PR DESCRIPTION
The call to *Analizer::tokenize* inside *highlightExtended* for an HTML document not set the encoding.