### PR TITLE
Use isset() instead of strlen()

### DIFF
--- a/library/ZendSearch/Lucene/Index/Term.php
+++ b/library/ZendSearch/Lucene/Index/Term.php
@@ -75,7 +75,7 @@ class Term
          */
         $prefixBytes = 0;
         $prefixChars = 0;
-        while ($prefixBytes < strlen($str)  &&  $prefixChars < $length) {
+        while (isset($str[$prefixBytes])  &&  $prefixChars < $length) {
             $charBytes = 1;
             if ((ord($str[$prefixBytes]) & 0xC0) == 0xC0) {
                 $charBytes++;
@@ -87,7 +87,7 @@ class Term
                 }
             }
 
-            if ($prefixBytes + $charBytes > strlen($str)) {
+            if (! isset($str[$prefixBytes + $charBytes - 1])) {
                 // wrong character
                 break;
             }


### PR DESCRIPTION
`strlen()` is `O(n)` while `isset()` is `O(1)`. Thus this function was way too slow before and when called very often (e.g. 100k times with long string values) took more than one minute before for us at ownCloud.

This should make the function about 50% faster according to the blackfire.io profiler. (and also reduce the overall memory usage)

A simple test script showed the following changes for me:

![screen shot 2015-01-15 at 12 29 44](https://cloud.githubusercontent.com/assets/878997/5756655/394e9968-9cb2-11e4-8f17-709e137536d3.png)
